### PR TITLE
Add all_frames flag so that embedded videos are fixed, too

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*", "*://*.vimeo.com/*"],
-      "js": ["video-bg-play-content.js"]
+      "js": ["video-bg-play-content.js"],
+      "all_frames": true
     }
   ]
 }


### PR DESCRIPTION
So, currently this addon does a great job of fixing videos on the YouTube site, but it has one flaw.  It doesn't work on embedded YouTube videos.  This Pull Request simply adds the necessary flag so that the script will get injected into the embedded video iframes, too.